### PR TITLE
同じ PMD ファイルを再生中の場合は、 BGM を頭出し再生しないように

### DIFF
--- a/pceth2_snd.c
+++ b/pceth2_snd.c
@@ -123,15 +123,16 @@ BYTE	*pmd;
  */
 void Play_PieceMML(const char *fName)
 {
-	Stop_PieceMML();
+	if (!pmd || strcmp(play.pmdname, fName) != 0) {
+		Stop_PieceMML();
+		strcpy(play.pmdname, fName);
+		pmd = fpk_getEntryData(play.pmdname, NULL, NULL);
 
-	strcpy(play.pmdname, fName);
-	pmd = fpk_getEntryData(play.pmdname, NULL, NULL);
-
-	if (pmd != NULL) {
-		PlayMusic(pmd);
-	} else {
-		*play.pmdname = '\0';
+		if (pmd != NULL) {
+			PlayMusic(pmd);
+		} else {
+			*play.pmdname = '\0';
+		}
 	}
 }
 


### PR DESCRIPTION
単純に文字列比較だけだと、セーブデータから復帰した時に BGM が鳴らなかったので、 BGM 読み込み領域のヌルチェックもするようにした。