### PR TITLE
#5 make map select graphical 2

### DIFF
--- a/mk.bat
+++ b/mk.bat
@@ -3,10 +3,32 @@ if "%1" == "clean" goto clean
 @echo on
 
 unpack000 -bm2
-del *T.BM2 F*.BM2 THUM*.BM2 THLF*.BM2 BAR*.BM2 BUTTON*.BM2 NE*.BM2 OPTION*.BM2
+del F*.BM2 THLF*.BM2 BAR*.BM2 BUTTON*.BM2 NE*.BM2 OPTION*.BM2
 del ALBUM.BM2 BG.BM2 DATE.BM2 FRAME.BM2 GENERAL.BM2 MAPSELECT.BM2 MEMOCA.BM2 SAKURA.BM2 SAVELOAD.BM2 TITLE.BM2 YESNO.BM2
 th2bm2cmv *.BM2
 pceth2bmp *.bmp
+pceth2map MAP01.bmp MAP0000.bmp THUM01A.bmp THUM01M.bmp B054000T.bmp
+pceth2map MAP02.bmp MAP0200.bmp THUM02A.bmp THUM02M.bmp B031000T.bmp
+pceth2map MAP03.bmp MAP0200.bmp THUM03A.bmp THUM03M.bmp B033000T.bmp
+pceth2map MAP04.bmp MAP0300.bmp THUM04A.bmp THUM04M.bmp B069000T.bmp
+pceth2map MAP05.bmp MAP0300.bmp THUM05A.bmp THUM05M.bmp B046000T.bmp
+pceth2map MAP06.bmp MAP0400.bmp THUM06A.bmp THUM06M.bmp B040000T.bmp
+pceth2map MAP07.bmp MAP0400.bmp THUM07A.bmp THUM07M.bmp B001000T.bmp
+pceth2map MAP08.bmp MAP0100.bmp THUM08A.bmp THUM08M.bmp B025000T.bmp
+pceth2map MAP09.bmp MAP0100.bmp THUM09A.bmp THUM09M.bmp B010000T.bmp
+pceth2map MAP10.bmp MAP0100.bmp THUM10A.bmp THUM10M.bmp B026000T.bmp
+pceth2map MAP11.bmp MAP0100.bmp THUM11A.bmp THUM11M.bmp B016000T.bmp
+pceth2map MAP12.bmp MAP0100.bmp THUM12A.bmp THUM12M.bmp B021000T.bmp
+pceth2map MAP13.bmp MAP0100.bmp THUM13A.bmp THUM13M.bmp B024000T.bmp
+pceth2map MAP14.bmp MAP0100.bmp THUM14A.bmp THUM14M.bmp B023000T.bmp
+pceth2map MAP15.bmp MAP0100.bmp THUM15A.bmp THUM15M.bmp B011000T.bmp
+pceth2map MAP16.bmp MAP0100.bmp THUM16A.bmp THUM16M.bmp B013000T.bmp
+pceth2map MAP17.bmp MAP0100.bmp THUM17A.bmp THUM17M.bmp B014000T.bmp
+pceth2map MAP18.bmp MAP0100.bmp THUM18A.bmp THUM18M.bmp B012000T.bmp
+pceth2map MAP19.bmp MAP0100.bmp THUM19A.bmp THUM19M.bmp B009000T.bmp
+pceth2map MAP20.bmp MAP0100.bmp THUM20A.bmp THUM20M.bmp B015000T.bmp
+pceth2map MAP21.bmp MAP0100.bmp THUM21A.bmp THUM21M.bmp B009000T.bmp
+del *T.bmp THUM*.bmp
 pgd16cmv -b *.bmp
 
 copy /Y CAL\* .\

--- a/pceth2_grp.c
+++ b/pceth2_grp.c
@@ -37,13 +37,17 @@ static int	slide_pos;			// スライドしている画像のセット位置（LCR）
 //	画像描画
 //=============================================================================
 
-#define POS_L	30
-#define POS_C	64
-#define POS_R	98
-
 static void draw_object(const PIECE_BMP *pbmp, int dx, int dy)
 {
 	Ldirect_DrawObject(pbmp, dx, dy, 0, 0, pbmp->header.w, pbmp->header.h);
+}
+
+static void draw_character(int pos)
+{
+	static const int s_x[GRP_BG] = {30, 64, 98};	// 立ち絵表示中心位置テーブル
+	if (*play.pgxname[pos]) {
+		draw_object(&pbmp[pos], (s_x[pos] - pbmp[pos].header.w / 2) + slide_x[pos], DISP_Y - pbmp[pos].header.h);
+	}
 }
 
 /*
@@ -51,22 +55,20 @@ static void draw_object(const PIECE_BMP *pbmp, int dx, int dy)
  */
 void pceth2_DrawGraphic()
 {
-//	static int pos_table[] = {30, 64, 98};	// 立ち絵表示中心位置テーブル
-
 	if (*play.pgxname[GRP_BG]) {	// 背景
 		draw_object(&pbmp[GRP_BG], 0, 0);
 	} else {
 		Ldirect_Paint(15, 0, 0, DISP_X, DISP_Y);	// 黒背景
 	}
 
-	if (*play.pgxname[GRP_R]) {	// 右
-		draw_object(&pbmp[GRP_R], (POS_R - pbmp[GRP_R].header.w / 2) + slide_x[GRP_R], DISP_Y - pbmp[GRP_R].header.h);
-	}
-	if (*play.pgxname[GRP_L]) {	// 左
-		draw_object(&pbmp[GRP_L], (POS_L - pbmp[GRP_L].header.w / 2) + slide_x[GRP_L], DISP_Y - pbmp[GRP_L].header.h);
-	}
-	if (*play.pgxname[GRP_C]) {	// 中央
-		draw_object(&pbmp[GRP_C], (POS_C - pbmp[GRP_C].header.w / 2) + slide_x[GRP_C], DISP_Y - pbmp[GRP_C].header.h);
+	if(play.gameMode == GM_MAPSELECT) {
+		draw_character(GRP_C);
+		draw_character(GRP_L);
+		draw_character(GRP_R);
+	} else {
+		draw_character(GRP_R);
+		draw_character(GRP_L);
+		draw_character(GRP_C);
 	}
 }
 
@@ -80,7 +82,7 @@ void pceth2_DrawGraphic()
  *	*fName	画像ファイル名
  *	pos		表示位置
  */
-void pceth2_loadGraphic(const char *fName, int pos)
+void pceth2_loadGraphic(const char *fName, const int pos)
 {
 	pceth2_clearGraphic(pos);
 
@@ -99,7 +101,7 @@ void pceth2_loadGraphic(const char *fName, int pos)
  *
  *	pos	表示位置
  */
-void pceth2_clearGraphic(int pos)
+void pceth2_clearGraphic(const int pos)
 {
 	*play.pgxname[pos] = '\0';
 //	pceHeapFree(pgx[pos]);
@@ -141,7 +143,7 @@ int pceth2_loadBG(SCRIPT_DATA *s)
 {	// 桜背景画像変更テーブル
 	// 2005/07/19	回想などで直接画像番号を指定するケースもあるみたいなので、
 	//				使われていない画像番号にしてみる
-	static const char * const cherry[][6] = {
+	static const char *cherry[][6] = {
 		{"88", "78", "03", "01", "02", "04"},	// 校門（外）
 		{"89", "79", "07", "05", "06", "08"},	// 校門（内）
 		{"90", "80", "36", "34", "35", "37"},	// 橋

--- a/pceth2_msg.c
+++ b/pceth2_msg.c
@@ -74,8 +74,10 @@ void pceth2_comeBackMessage(void)
 	FontFuchi_SetPos(MSG_X_MIN, MSG_Y_MIN);
 	FontFuchi_PutStr(play.msg);
 
-	if (play.gameMode == GM_SELECT || play.gameMode == GM_MAPSELECT) {	// ‘I‘ð’†‚È‚ç–îˆó•`‰æ
+	if (play.gameMode == GM_SELECT) {	// ‘I‘ð’†‚È‚ç–îˆó•`‰æ
 		pceth2_drawSelArrow();
+	} else if (play.gameMode == GM_MAPSELECT) {
+		pceth2_drawMapSelArrow();
 	}
 	msgView = 1;
 	Ldirect_Update();

--- a/pceth2_sel.h
+++ b/pceth2_sel.h
@@ -9,6 +9,8 @@ int  pceth2_addSelItem(SCRIPT_DATA *s);
 int  pceth2_initSelect(SCRIPT_DATA *s);
 void pceth2_Select();
 
+void pceth2_drawMapSelArrow();
+
 int pceth2_addMapItem(SCRIPT_DATA *s);
 BOOL pceth2_initMapClock();
 void pceth2_initMapSelect();

--- a/pceth2_win.sln
+++ b/pceth2_win.sln
@@ -14,36 +14,60 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pceth2bin2", "pceth2bin2\pc
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "th2wav_mkbat", "th2wav_mkbat\th2wav_mkbat.vcxproj", "{8BC6DFCA-5A33-4168-A30B-4951AFE09217}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pceth2map", "pceth2map\pceth2map.vcxproj", "{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Debug|x64.ActiveCfg = Debug|Win32
 		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Debug|x86.ActiveCfg = Debug|Win32
 		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Debug|x86.Build.0 = Debug|Win32
+		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Release|x64.ActiveCfg = Release|Win32
 		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Release|x86.ActiveCfg = Release|Win32
 		{9AE56C73-F8CE-498F-88C1-62E7F15735A8}.Release|x86.Build.0 = Release|Win32
+		{234D94A6-ABBA-44CC-811F-096DA5810855}.Debug|x64.ActiveCfg = Debug|Win32
 		{234D94A6-ABBA-44CC-811F-096DA5810855}.Debug|x86.ActiveCfg = Debug|Win32
 		{234D94A6-ABBA-44CC-811F-096DA5810855}.Debug|x86.Build.0 = Debug|Win32
+		{234D94A6-ABBA-44CC-811F-096DA5810855}.Release|x64.ActiveCfg = Release|Win32
 		{234D94A6-ABBA-44CC-811F-096DA5810855}.Release|x86.ActiveCfg = Release|Win32
 		{234D94A6-ABBA-44CC-811F-096DA5810855}.Release|x86.Build.0 = Release|Win32
+		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Debug|x64.ActiveCfg = Debug|Win32
 		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Debug|x86.ActiveCfg = Debug|Win32
 		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Debug|x86.Build.0 = Debug|Win32
+		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Release|x64.ActiveCfg = Release|Win32
 		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Release|x86.ActiveCfg = Release|Win32
 		{4C2B6180-E2EC-484E-B94A-939B6A9E297D}.Release|x86.Build.0 = Release|Win32
+		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Debug|x64.ActiveCfg = Debug|Win32
 		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Debug|x86.ActiveCfg = Debug|Win32
 		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Debug|x86.Build.0 = Debug|Win32
+		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Release|x64.ActiveCfg = Release|Win32
 		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Release|x86.ActiveCfg = Release|Win32
 		{58D687AE-AF84-4555-B9EE-725F1E50DE1F}.Release|x86.Build.0 = Release|Win32
+		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Debug|x64.ActiveCfg = Debug|Win32
 		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Debug|x86.ActiveCfg = Debug|Win32
 		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Debug|x86.Build.0 = Debug|Win32
+		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Release|x64.ActiveCfg = Release|Win32
 		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Release|x86.ActiveCfg = Release|Win32
 		{C8DF5065-7E17-468D-BB07-E3189FFD05B2}.Release|x86.Build.0 = Release|Win32
+		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Debug|x64.ActiveCfg = Debug|Win32
 		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Debug|x86.ActiveCfg = Debug|Win32
 		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Debug|x86.Build.0 = Debug|Win32
+		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Release|x64.ActiveCfg = Release|Win32
 		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Release|x86.ActiveCfg = Release|Win32
 		{8BC6DFCA-5A33-4168-A30B-4951AFE09217}.Release|x86.Build.0 = Release|Win32
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Debug|x64.ActiveCfg = Debug|x64
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Debug|x64.Build.0 = Debug|x64
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Debug|x86.ActiveCfg = Debug|Win32
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Debug|x86.Build.0 = Debug|Win32
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Release|x64.ActiveCfg = Release|x64
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Release|x64.Build.0 = Release|x64
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Release|x86.ActiveCfg = Release|Win32
+		{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/pceth2map/main.cpp
+++ b/pceth2map/main.cpp
@@ -1,0 +1,164 @@
+/*
+ *	pceth2map
+ *	特定の16階調PGD変換用のグレースケールBMPを合成して、マップ選択用の画像を生成します。
+ *
+ *	(c)2017 zurachu
+ */
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+bool open_bmp(char const* filename, BITMAPFILEHEADER* out_bf
+	, BITMAPINFOHEADER& out_bi, RGBQUAD* out_rgb, BYTE*& out_bmp);
+BYTE* resize128(BYTE* bmp, BITMAPINFOHEADER* bi);
+void combine(BYTE* dst,  BITMAPINFOHEADER const& dst_bi
+	, BYTE const* src, BITMAPINFOHEADER const& src_bi);
+void combine_with_mask(BYTE* dst, BITMAPINFOHEADER const& dst_bi
+	, BYTE const* src, BITMAPINFOHEADER const& src_bi
+	, int offset_x, int offset_y);
+
+int main(int argc, char *argv[])
+{
+	FILE	*fp = NULL;
+	BITMAPFILEHEADER	bf;
+	BITMAPINFOHEADER	map_bi, thum_a_bi, thum_m_bi, b_bi;
+	RGBQUAD	rgb[256];
+	BYTE	*map_bmp = NULL, *thum_a_bmp = NULL, *thum_m_bmp = NULL, *b_bmp = NULL;
+	int	i;
+
+	if(argc != 6) {	// usage
+		fprintf(stderr, "ToHeart2 マップ選択用画像合成\n");
+		fprintf(stderr, "pceth2map out_filename MAPxxxx.bmp THUMxxA.bmp THUMxxM.bmp BxxxxxxT.bmp\n");
+		return 1;
+	}
+
+	i = 2; if (!open_bmp(argv[i], &bf, map_bi, rgb, map_bmp)) goto ERR;
+	map_bmp = resize128(map_bmp, &map_bi);
+	i = 3; if (!open_bmp(argv[i], NULL, thum_a_bi, NULL, thum_a_bmp)) goto ERR;
+	i = 4; if (!open_bmp(argv[i], NULL, thum_m_bi, NULL, thum_m_bmp)) goto ERR;
+	i = 5; if (!open_bmp(argv[i], NULL, b_bi, NULL, b_bmp)) goto ERR;
+
+	combine_with_mask(thum_m_bmp, thum_m_bi, b_bmp, b_bi, 6, 10);
+	combine(map_bmp, map_bi, thum_a_bmp, thum_a_bi);
+	combine(map_bmp, map_bi, thum_m_bmp, thum_m_bi);
+
+	i = 1; if ((fp = fopen(argv[i], "wb")) == NULL)	goto ERR;
+	fwrite(&bf, 1, sizeof(BITMAPFILEHEADER), fp);
+	fwrite(&map_bi, 1, sizeof(BITMAPINFOHEADER), fp);
+	fwrite(rgb, 1, sizeof(RGBQUAD) * 256, fp);
+	fwrite(map_bmp, 1, map_bi.biWidth * map_bi.biHeight, fp);
+	printf("%s - 成功しました。\n", argv[i]);
+	goto FREE;
+ERR:
+		fprintf(stderr, "%s - 失敗しました。\n", argv[i]);
+FREE:
+	if(fp != NULL) fclose(fp);
+	if(b_bmp != NULL) free(b_bmp);
+	if(thum_m_bmp != NULL) free(thum_m_bmp);
+	if(thum_a_bmp != NULL) free(thum_a_bmp);
+	if(map_bmp != NULL) free(map_bmp);
+	return 0;
+}
+
+bool open_bmp(char const* filename, BITMAPFILEHEADER* out_bf
+	, BITMAPINFOHEADER& out_bi, RGBQUAD* out_rgb, BYTE*& out_bmp)
+{
+	FILE	*fp = NULL;
+	BITMAPFILEHEADER	bf;
+	BITMAPINFOHEADER	bi;
+	RGBQUAD	rgb[256];
+	BYTE	*bmp;
+
+	if(out_bmp) goto ERR;
+	if((fp = fopen(filename, "rb")) == NULL) goto ERR;
+	// BITMAPFILEHEADER
+	if(fread(&bf, 1, sizeof(BITMAPFILEHEADER), fp) != sizeof(BITMAPFILEHEADER)) goto ERR;
+	if(strncmp((char*)&bf.bfType, "BM", 2)) goto ERR;
+	// BITMAPINFOHEADER
+	if(fread(&bi, 1, sizeof(BITMAPINFOHEADER), fp) != sizeof(BITMAPINFOHEADER)) goto ERR;
+	if(bi.biSize != sizeof(BITMAPINFOHEADER)) goto ERR;
+	if(bi.biBitCount != 8) goto ERR;
+	fread(rgb, 1, sizeof(RGBQUAD) * 256, fp);
+	// BITMAP本体（ボトムアップで読み込む）
+	if((bmp = (BYTE*)malloc(bi.biWidth * abs(bi.biHeight))) == NULL) goto ERR;
+	if(bi.biHeight < 0) {	// トップダウン
+		bi.biHeight = -bi.biHeight;
+		for(int y = bi.biHeight - 1; y >= 0; y--) {
+			fread(bmp + bi.biWidth * y, 1, bi.biWidth, fp);
+		}
+	} else {				// ボトムアップ
+		fread(bmp, 1, bi.biWidth * bi.biHeight, fp);
+	}
+	fclose(fp);
+	if(out_bf) *out_bf = bf;
+	out_bi = bi;
+	if(out_rgb) memcpy(out_rgb, rgb, sizeof(RGBQUAD) * 256);
+	out_bmp = bmp;
+	return true;
+
+ERR:
+	if(fp != NULL) fclose(fp);
+	return false;
+}
+
+BYTE* resize128(BYTE* bmp, BITMAPINFOHEADER* bi)
+{
+	static int const new_width = 128;
+	int offset = 0, new_offset = (new_width - bi->biWidth) / 2;
+	BYTE* new_bmp = (BYTE*)malloc(new_width * bi->biHeight);
+	memset(new_bmp, 16, new_width * bi->biHeight);
+	for (int y = 0; y < bi->biHeight; y++)
+	{
+		for (int x = 0; x < bi->biWidth; x++)
+		{
+			*(new_bmp + new_offset) = *(bmp + offset);
+			new_offset++;
+			offset++;
+		}
+		new_offset += new_width - bi->biWidth;
+	}
+	bi->biWidth = new_width;
+	free(bmp);
+	return new_bmp;
+}
+
+void combine(BYTE* dst,  BITMAPINFOHEADER const& dst_bi
+	, BYTE const* src, BITMAPINFOHEADER const& src_bi)
+{
+	for(int y = 0; y < src_bi.biHeight; y++)
+	{
+		for(int x = 0; x < src_bi.biWidth; x++)
+		{
+			if(*src < 16)
+			{
+				*dst = *src;
+			}
+			dst++;
+			src++;
+		}
+		dst += dst_bi.biWidth - src_bi.biWidth;
+	}
+}
+
+void combine_with_mask(BYTE* dst, BITMAPINFOHEADER const& dst_bi
+	, BYTE const* src, BITMAPINFOHEADER const& src_bi
+	, int offset_x, int offset_y)
+{
+	dst += offset_y * dst_bi.biWidth + offset_x;
+	for(int y = 0; y < src_bi.biHeight; y++)
+	{
+		for(int x = 0; x < src_bi.biWidth; x++)
+		{
+			if(*dst == 0 && *src < 16)
+			{
+				*dst = *src;
+			}
+			dst++;
+			src++;
+		}
+		dst += dst_bi.biWidth - src_bi.biWidth;
+	}
+}

--- a/pceth2map/pceth2map.vcxproj
+++ b/pceth2map/pceth2map.vcxproj
@@ -1,0 +1,148 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>15.0</VCProjectVersion>
+    <ProjectGuid>{322CECEE-02E1-4F05-8B29-5D8C598E8DCA}</ProjectGuid>
+    <Keyword>Win32Proj</Keyword>
+    <RootNamespace>pceth2map</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v141</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <OutputFile>$(OutDir)$(TargetName)$(TargetExt)</OutputFile>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/pceth2map/pceth2map.vcxproj.filters
+++ b/pceth2map/pceth2map.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="ソース ファイル">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="ヘッダー ファイル">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="リソース ファイル">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="main.cpp">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
https://github.com/zurachu/pceth2/issues/5#issuecomment-315785125 に従って、THUMxxx.bmp を MAPxxxx.bmp に左詰めで合成。
MAPxxxx.bmp が画面フルサイズでないもの（MAP0400.bmp のみ）は画面フルサイズに拡張。
![map_select](https://user-images.githubusercontent.com/29687119/28449290-8582d282-6e19-11e7-9004-00f561251002.png)
この画像が無いゲームデータの場合や、従来のマップ選択画面でのセーブデータからの復帰は、
従来の文字列ベースの選択画面になる。