### PR TITLE
#20 support 6a command

### DIFF
--- a/main.c
+++ b/main.c
@@ -434,7 +434,7 @@ int pceth2_readScript(SCRIPT_DATA *s)
 						{'-', pceth2_decReg},		// レジスタをデクリメント
 						{'q',  pceth2_addSelItem},	// 選択肢を追加
 						{'Q',  pceth2_initSelect},	// 選択
-						{'@',  pceth2_skipLabel},	// ラベル（読み飛ばし）
+						{'@',  pceth2_memoryLabel},	// ラベル（直近のものを記憶）
 						{'<',  pceth2_procControl},	// メッセージ制御
 						{'\\', pceth2_procEscape},	// エスケープシーケンス処理
 						{'D', pceth2_calenderInitEx},	// スクリプトからカレンダーモードに移行

--- a/pceth2_grp.c
+++ b/pceth2_grp.c
@@ -84,13 +84,13 @@ void pceth2_DrawGraphic()
  */
 void pceth2_loadGraphic(const char *fName, const int pos)
 {
-	if (!pgx[pos] || strcmp(play.pgxname[pos], fName) != 0) {
+	if (!*pgx[pos] || strcmp(play.pgxname[pos], fName) != 0) {
 		pceth2_clearGraphic(pos);
 
 		strcpy(play.pgxname[pos], fName);
 		/*pgx[pos] =*/ fpk_getEntryData(play.pgxname[pos], NULL, pgx[pos]);
 
-		if (pgx[pos] != NULL) {
+		if (*pgx[pos]) {
 			PieceBmp_Construct(&pbmp[pos], pgx[pos]);
 		} else {
 			*play.pgxname[pos] = '\0';
@@ -106,8 +106,7 @@ void pceth2_loadGraphic(const char *fName, const int pos)
 void pceth2_clearGraphic(const int pos)
 {
 	*play.pgxname[pos] = '\0';
-//	pceHeapFree(pgx[pos]);
-//	pgx[pos] = NULL;
+	*pgx[pos] = '\0';
 	memset(pbmp[pos], 0, sizeof(PIECE_BMP));
 }
 

--- a/pceth2_grp.c
+++ b/pceth2_grp.c
@@ -84,15 +84,17 @@ void pceth2_DrawGraphic()
  */
 void pceth2_loadGraphic(const char *fName, const int pos)
 {
-	pceth2_clearGraphic(pos);
+	if (!pgx[pos] || strcmp(play.pgxname[pos], fName) != 0) {
+		pceth2_clearGraphic(pos);
 
-	strcpy(play.pgxname[pos], fName);
-	/*pgx[pos] =*/ fpk_getEntryData(play.pgxname[pos], NULL, pgx[pos]);
+		strcpy(play.pgxname[pos], fName);
+		/*pgx[pos] =*/ fpk_getEntryData(play.pgxname[pos], NULL, pgx[pos]);
 
-	if (pgx[pos] != NULL) {
-		PieceBmp_Construct(&pbmp[pos], pgx[pos]);
-	} else {
-		*play.pgxname[pos] = '\0';
+		if (pgx[pos] != NULL) {
+			PieceBmp_Construct(&pbmp[pos], pgx[pos]);
+		} else {
+			*play.pgxname[pos] = '\0';
+		}
 	}
 }
 

--- a/pceth2_sav.c
+++ b/pceth2_sav.c
@@ -355,9 +355,9 @@ void pceth2_SaveMenu()
 /*
  *	セーブデータから各種状態復帰
  *
- *	musplay_flag	0なら音楽を再生し直さない（セーブメニューから復帰しただけの時）
+ *	replay_flag	0なら画像、音楽を再生し直さない（セーブメニューから復帰しただけの時）
  */
-static void pceth2_comeBack(int musplay_flag)
+static void pceth2_comeBack(int replay_flag)
 {
 	char	buf[16];	// ファイル名退避用
 	int		i;
@@ -369,16 +369,18 @@ static void pceth2_comeBack(int musplay_flag)
 		play.flag[80] += play.flag[80 + i];
 	}
 
-	for (i = 0; i < GRP_NUM; i++) {
-		strcpy(buf, play.pgxname[i]);
-		pceth2_loadGraphic(buf, i);
-	}
-	pceth2_DrawGraphic();	// 画像描画
+	if (replay_flag) {
+		for (i = 0; i < GRP_NUM; i++) {
+			strcpy(buf, play.pgxname[i]);
+			pceth2_clearGraphic(i);
+			pceth2_loadGraphic(buf, i);
+		}
 
-	if (musplay_flag) {
 		strcpy(buf, play.pmdname);
+		Stop_PieceMML();
 		Play_PieceMML(buf);	// BGM再生
 	}
+	pceth2_DrawGraphic();	// 画像描画
 
 	play.evData.data = fpk_getEntryData(play.evData.name, &play.evData.size, NULL);	// EV
 	play.scData.data = fpk_getEntryData(play.scData.name, &play.scData.size, NULL);	// スクリプト

--- a/pceth2_sys.h
+++ b/pceth2_sys.h
@@ -21,7 +21,7 @@ int pceth2_jumpScript(SCRIPT_DATA *s);
 //=============================================================================
 //	ƒ‰ƒxƒ‹ƒWƒƒƒ“ƒv
 //=============================================================================
-int pceth2_skipLabel(SCRIPT_DATA *s);
+int pceth2_memoryLabel(SCRIPT_DATA *s);
 int pceth2_jumpLabel(SCRIPT_DATA *s);
 int pceth2_branchLabel(SCRIPT_DATA *s);
 

--- a/pceth2bin2/func.cpp
+++ b/pceth2bin2/func.cpp
@@ -102,7 +102,7 @@ int calcRevPolish(const BYTE *ptr, int *num)
 	if (ret == 0) {
 		return 0;
 	}
-	*num = (buf[0] < 0)? *num : buf[0];	// -1ならデフォルト値
+	*num = buf[0];
 	return ret;
 }
 

--- a/pceth2bin2/main.cpp
+++ b/pceth2bin2/main.cpp
@@ -356,6 +356,15 @@ int main(int argc, char *argv[])
 							if (!strcmp(str, bl[k].name)) { fprintf(fpout, "j%03d", k); }
 						}
 						break;
+					case 0x6A:	// アニメーション（座標に使っている演算処理 0x04 をスキップしているので、単純に表示するだけ）
+						for (int k = 0; k < 2; k++) { j += getNumber(buf + j, &num[k]) + 1; }
+						j += getString(buf + j, str) + 1;
+						*str = toupper(*str);
+						if (*str != 'F') { // 効果は使用しない
+							*strchr(str, '.') = '\0';
+							fprintf(fpout, "%s.pgx,0", str);
+						}
+						break;
 					case 0x74:	// マップ移動選択肢を追加
 						for(int k = 0; k < 3; k++) { j += getNumber(buf + j, &num[k]) + 1; }
 						j += getString(buf + j, str) + 1;

--- a/pceth2bin2/main.cpp
+++ b/pceth2bin2/main.cpp
@@ -229,14 +229,15 @@ int main(int argc, char *argv[])
 						for (int k = 0; k < 3; k++) {
 							if (len = calcRevPolish(buf + j, &num[k])) { j += len + 1; }
 						}
-						num[1] = convertBGNum(num[1]);	// 桜統一
+						if (num[1] >= 0) { // 0x6A の後に出てくることがある -1 は無視する
+							num[1] = convertBGNum(num[1]);	// 桜統一
 //**					if (!(code == 0x27 && num[0] == 0)) {	// これはレイヤアニメ無視するんだったら表示しない方が？
 /*							if (code & 1) {	// 立ち絵消去するなら位置初期化
 								for (int q = 0; q < array_size(pos); q++) { pos[q] = 1; }
 							}
 							// 10000足されてると桜背景も日付無視して表示するらしい（回想など）
 */							fprintf(fpout, "B%03d%03d.pgx,%1d", num[1] % 1000, num[2], (code - 0x27) % 2);
-//**					}
+						}
 						break;
 /*					case 0x2E:	// 立ち絵画像C xxx yyyyy .pgxの表示（位置z）（すぐに描く）
 					case 0x2F:	// （すぐには描かない）→P/ECEでは変わらないので共通にしました


### PR DESCRIPTION
6Aに対応して、 Fxxxx.bmp 以外は止め絵で表示するようにスクリプト変換を改修。
あわせて、直後の背景暗転が間違いっぽかったのでこれもスクリプト変換で対応。
P/ECE側実行ファイルも、直後の同名ファイルの読み込み省略やラベルジャンプのループ速度改善を実施。