### PR TITLE
#40_delete_make_mml

### DIFF
--- a/mk.bat
+++ b/mk.bat
@@ -50,7 +50,6 @@ FOR %%A IN (EV_????NIGHT.BIN) DO CALL :RENAME_EV_BIN %%A 6
 @echo on
 pceth2bin2 -s *.BIN
 
-make -C mml
 copy /Y mml\*.pmd .\
 
 par c -C -T pceth2.par -f *.pgx *.pgd *.ppd *.scp *.pmd


### PR DESCRIPTION
ゲームデータ変換においてmmlからpmdに変換するルールが実行時エラーになっていたが、BGMは既にpmd形式でプロジェクトに格納しているので、不要のため削除